### PR TITLE
Update Widgetsnbextension to version 3.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.5.1" %}
+{% set version = "3.5.2" %}
 
 package:
   name: widgetsnbextension
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/w/widgetsnbextension/widgetsnbextension-{{ version }}.tar.gz
-  sha256: 079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7
+  sha256: e0731a60ba540cd19bbbefe771a9076dcd2dde90713a8f87f27f53f2d1db7727
 
 build:
   number: 0


### PR DESCRIPTION
  widgetsnbextension 3.5.2
1. check the upstream

2. check the pinnings
    https://github.com/jupyter-widgets/ipywidgets/blob/master/package.json
    https://github.com/jupyter-widgets/ipywidgets/blob/master/lerna.json
    https://github.com/jupyter-widgets/ipywidgets/blob/master/package.json
    
3. check the changelogs

4. additional research
    http://github.com/conda-forge/widgetsnbextension-feedstock/issues

5. verify dev_url

6. verify doc_url
    https://pypi.python.org/pypi/widgetsnbextension

7. pip in the test section
8. veriy the test section
9. additional tests
