### PR TITLE
widgetsnbextension 3.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,32 +11,26 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
     - python
-    - jupyter-packaging >=0.10,<2
     - pip
     - setuptools
     - wheel
   run:
     - python
-    # notebook was deleted from the upstream install_requires on 2020/01/08,
-    # see https://github.com/jupyter-widgets/ipywidgets/commit/7ea681eb07e76796534ac1885d8e60ea9eb92b97
-    #- notebook >=4.4.1
+    - notebook >=4.4.1
 
 test:
   imports:
     - widgetsnbextension
-  #requires:
-    #- pip
-  #commands:
-    # pip false positive checks notebook as a required dependency,
-    # notebook was deleted from install_requires on 2020/01/08,
-    # see https://github.com/jupyter-widgets/ipywidgets/commit/7ea681eb07e76796534ac1885d8e60ea9eb92b97
-    #- pip check
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: http://ipython.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,6 @@ requirements:
 test:
   imports:
     - widgetsnbextension
-  downstreams:
-    - ipywidgets  # [not (osx and arm64)]
   #requires:
     #- pip
   #commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,13 @@ requirements:
 test:
   imports:
     - widgetsnbextension
-  requires:
-    - pip
-  commands:
-    - pip check
+  #requires:
+    #- pip
+  #commands:
+    # pip false positive checks notebook as a required dependency,
+    # notebook was deleted from install_requires on 2020/01/08,
+    # see https://github.com/jupyter-widgets/ipywidgets/commit/7ea681eb07e76796534ac1885d8e60ea9eb92b97
+    #- pip check
 
 about:
   home: http://ipython.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ test:
   imports:
     - widgetsnbextension
   downstreams:
-    - ipywidgets
+    - ipywidgets  # [not (osx and arm64)]
   #requires:
     #- pip
   #commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
 test:
   imports:
     - widgetsnbextension
+  downstreams:
+    - ipywidgets
   #requires:
     #- pip
   #commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,26 @@
-{% set version = "3.5.1" %}
+{% set name = "widgetsnbextension" %}
+{% set version = "3.5.2" %}
 
 package:
-  name: widgetsnbextension
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/w/widgetsnbextension/widgetsnbextension-{{ version }}.tar.gz
-  sha256: 079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/widgetsnbextension-{{ version }}.tar.gz
+  sha256: e0731a60ba540cd19bbbefe771a9076dcd2dde90713a8f87f27f53f2d1db7727
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
     - python
+    - jupyter-packaging >=0.10,<2
     - pip
-    - notebook >=4.4.1
+    - setuptools
+    - wheel
   run:
     - python
     - notebook >=4.4.1
@@ -24,17 +28,21 @@ requirements:
 test:
   imports:
     - widgetsnbextension
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: http://ipython.org
-  license: BSD 3-clause
+  license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
   summary: Interactive Widgets for Jupyter
   description: |
     Interactive HTML widgets for Jupyter notebooks.
   doc_url: https://pypi.python.org/pypi/widgetsnbextension
-  dev_url: https://github.com/jupyter-widgets/ipywidgets/tree/master/widgetsnbextension
+  dev_url: https://github.com/jupyter-widgets/ipywidgets/tree/master/python/widgetsnbextension
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - wheel
   run:
     - python
+    - notebook >=4.4.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - wheel
   run:
     - python
-    - notebook >=4.4.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,9 @@ requirements:
     - wheel
   run:
     - python
-    - notebook >=4.4.1
+    # notebook was deleted from the upstream install_requires on 2020/01/08,
+    # see https://github.com/jupyter-widgets/ipywidgets/commit/7ea681eb07e76796534ac1885d8e60ea9eb92b97
+    #- notebook >=4.4.1
 
 test:
   imports:


### PR DESCRIPTION
Upstream `widgetsnbextension 3.5.2` is in **7.x branch** https://github.com/jupyter-widgets/ipywidgets/tree/7.x/widgetsnbextension

License :https://github.com/jupyter-widgets/ipywidgets/blob/7.x/widgetsnbextension/LICENSE
Upstream requirements: https://github.com/jupyter-widgets/ipywidgets/blob/7.x/widgetsnbextension/setup.py

Actions:
1.  Add in `host`: `setuptools`, `wheel`
2. Remove `notebook `from `host`.
3. Add `pip check`
4. Update license name
5. Update `dev_url`
6. Add `downstreams` in `test` for additional testing: `ipywidgets   # [not (osx and arm64)]` 