### PR TITLE
Services2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+aggregate_check: false
+
+upload_channels:
+  - services
+
+channels:
+  - services
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "widgetsnbextension" %}
-{% set version = "3.5.2" %}
+{% set version = "3.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/widgetsnbextension-{{ version }}.tar.gz
-  sha256: e0731a60ba540cd19bbbefe771a9076dcd2dde90713a8f87f27f53f2d1db7727
+  sha256: e84a7a9fcb9baf3d57106e184a7389a8f8eb935bf741a5eb9d60aa18cc029a80
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,11 @@ about:
   dev_url: https://github.com/jupyter-widgets/ipywidgets/tree/master/python/widgetsnbextension
 
 extra:
+  anaconda-services:
+    comment: "Built for customer needed 3.6.0 without pre/post-link scripts"
+    recipe_maintainers:
+      - bkreider 
+    ref: https://anaconda.zendesk.com/agent/tickets/26726
   recipe-maintainers:
     - jasongrout
     - jakirkham


### PR DESCRIPTION
Citi was having problems with the conda-forge version of 3.6.0 which uses pre/post link steps.  this was breaking parcels for them.  https://anaconda.zendesk.com/agent/tickets/26726

