### PR TITLE
widgetsnbextension 4.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "widgetsnbextension" %}
-{% set version = "3.5.2" %}
+{% set version = "4.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/widgetsnbextension-{{ version }}.tar.gz
-  sha256: e0731a60ba540cd19bbbefe771a9076dcd2dde90713a8f87f27f53f2d1db7727
+  sha256: 34824864c062b0b3030ad78210db5ae6a3960dfb61d5b27562d6631774de0286
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,8 @@ about:
   license_family: BSD
   summary: Interactive Widgets for Jupyter
   description: |
-    Interactive Jupyter widgets for the classic Jupyter Notebook application. This package provides the necessary JavaScript controls in the Jupyter Notebook that communicate with the widget objects in the kernel.
+    Interactive Jupyter widgets for the classic Jupyter Notebook application. 
+    This package provides the necessary JavaScript controls in the Jupyter Notebook that communicate with the widget objects in the kernel.
   doc_url: https://pypi.python.org/pypi/widgetsnbextension
   dev_url: https://github.com/jupyter-widgets/ipywidgets/tree/master/python/widgetsnbextension
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   host:
     - python
-    - jupyter-packaging
+    - jupyter-packaging <2
     - pip
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,18 +11,18 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps -vvv
 
 requirements:
   host:
     - python
+    - jupyter-packaging
     - pip
     - setuptools
     - wheel
   run:
     - python
-    - notebook >=4.4.1
 
 test:
   imports:
@@ -39,7 +39,7 @@ about:
   license_family: BSD
   summary: Interactive Widgets for Jupyter
   description: |
-    Interactive HTML widgets for Jupyter notebooks.
+    Interactive Jupyter widgets for the classic Jupyter Notebook application. This package provides the necessary JavaScript controls in the Jupyter Notebook that communicate with the widget objects in the kernel.
   doc_url: https://pypi.python.org/pypi/widgetsnbextension
   dev_url: https://github.com/jupyter-widgets/ipywidgets/tree/master/python/widgetsnbextension
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
     - pip check
 
 about:
-  home: http://ipython.org
+  home: https://ipython.org
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD


### PR DESCRIPTION
**Jira ticket:** [PKG-729](https://anaconda.atlassian.net/browse/PKG-729) (widgetsnbextension 4.0.3)

**The upstream data:**
Github:  https://github.com/jupyter-widgets/ipywidgets/tree/master/python/widgetsnbextension
License: https://github.com/jupyter-widgets/ipywidgets/blob/master/python/widgetsnbextension/LICENSE
Requirements:
- https://github.com/jupyter-widgets/ipywidgets/blob/master/python/widgetsnbextension/setup.cfg
- https://github.com/jupyter-widgets/ipywidgets/blob/master/python/widgetsnbextension/pyproject.toml
- https://github.com/jupyter-widgets/ipywidgets/blob/master/python/widgetsnbextension/setup.py
- https://github.com/conda-forge/widgetsnbextension-feedstock/blob/main/recipe/meta.yaml

**_Actions:_**

1. Skip `py<37`
2. Update `script`
3. Add `jupyter-packaging` to `host`
4. Remove `notebook` from `run`
5. Fix `home` url with HTTPS
6. Update `description`

**_Notes:_**
 * It depended on `notebook` package but starting **v4.0.0** it's no more needed, see conda-forge recipe https://github.com/conda-forge/widgetsnbextension-feedstock/commit/6e870c6f02d93ee785557f7d6c91ce2fdf49660f

**Package's statistics**
<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 4.0.3
 * Release on PyPi:
    * version: 4.0.3
    * date: 2022-09-02T18:39:35
* [PyPi history](https://pypi.org/project/widgetsnbextension/#history)
 * Popularity: 
    * 3 months downloads: 857447.0
    * All time:  7525810 downloads -  widgetsnbextension  4.0.3  Interactive Widgets for Jupyter  

</details>

**Other checks:**

<details>

7. - [x] Check the pinnings
8. - [x] `dev_url` is present
    https://github.com/jupyter-widgets/ipywidgets/tree/master/python/widgetsnbextension
9. - [x] Verify that the `build_number` is correct
10. - [x] has `setuptools`
11. - [x] has `wheel`
12. - [x] `pip` in test
13. - [x] Verify the test section
14. - [x] Verify if the package is `architecture specific`
15. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
16.  - [x] license_file: LICENSE is present
17. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

18. - [x] license_family BSD is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/widgetsnbextension-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/widgetsnbextension-feedstock/tree/4.0.3)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/widgetsnbextension)
* [Diff between upstream and feature branch](https://github.com/conda-forge/widgetsnbextension-feedstock/compare/main...AnacondaRecipes:4.0.3)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/widgetsnbextension-feedstock/compare/master...AnacondaRecipes:4.0.3)
* [The last merged PRs](https://github.com/AnacondaRecipes/widgetsnbextension-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 4.0.3 git@github.com:AnacondaRecipes/widgetsnbextension-feedstock.git
```
