### PR TITLE
widgetsnbextension 4.0.13 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "widgetsnbextension" %}
-{% set version = "4.0.10" %}
+{% set version = "4.0.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/widgetsnbextension-{{ version }}.tar.gz
-  sha256: 64196c5ff3b9a9183a8e699a4227fb0b7002f252c814098e66c4d1cd0644688f
+  sha256: ffcb67bc9febd10234a362795f643927f4e0c05d9342c727b65d2384f8feacb6
 
 build:
   number: 0


### PR DESCRIPTION
widgetsnbextension 4.0.13 

**Destination channel:** Defaults

### Links

- [PKG-6423]
- dev_url:        https://github.com/jupyter-widgets/ipywidgets/tree/main
- pypi: https://pypi.org/project/widgetsnbextension/4.0.13/

### Explanation of changes:

- new version number
- required for https://github.com/AnacondaRecipes/ipywidgets-feedstock/pull/14

[PKG-6423]: https://anaconda.atlassian.net/browse/PKG-6423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ